### PR TITLE
Avoid inner div

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,10 +130,8 @@ export default class ClampLines extends PureComponent {
     }
 
     return (
-      <div className={this.getClassName()}>
-        <div ref={e => { this.element = e; }}>
-            {this.state.text}
-        </div>
+      <div className={this.getClassName()} ref={e => { this.element = e; }}>
+        {this.state.text}
         {this.getButton()}
       </div>
     );


### PR DESCRIPTION
Hey,

Thanks for creating this library, it works like a charm!

However I want to ask why the inner `div` is necessary.

It's broken my className selection because it creates a wrapper.

Can we remove it?