### PR TITLE
Make webpack and react dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,7 @@
     "build": "webpack"
   },
   "peerDependencies": {
-    "react": "^16.2.0"
-  },
-  "dependencies": {
-    "react": "^16.2.0",
-    "webpack": "^2.6.1"
+    "react": "^15 || ^16"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -19,7 +15,9 @@
     "babel-loader": "^7.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-preset-env": "^1.5.1"
+    "babel-preset-env": "^1.5.1",
+    "react": "^16.2.0",
+    "webpack": "^2.6.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`webpack` is only used at build time, so it should be a dev dependency. This matter when using the commands `yarn install --production` or `npm install --only=production` to install only packages needed for production.

Same thing for react, the specific version used at build/test time (^16.2.0) should not be required in production, as it is already a peer dependency. Also changed it to accept any 15+ or 16+ react.