### PR TITLE
Basic support for server-side rendering

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,17 +127,22 @@ var ClampLines = function (_PureComponent) {
       text: '.'
     };
 
+    // If window is undefined it means the code is executed server-side
+    _this.ssr = typeof window === 'undefined';
+
     _this.action = _this.action.bind(_this);
     _this.clickHandler = _this.clickHandler.bind(_this);
 
-    _this.debounced = _this.debounce(_this.action, props.delay);
+    if (!_this.ssr) {
+      _this.debounced = _this.debounce(_this.action, props.delay);
+    }
     return _this;
   }
 
   _createClass(ClampLines, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      if (this.props.text) {
+      if (this.props.text && !this.ssr) {
         this.lineHeight = this.element.clientHeight + 1;
         this.clampLines();
 
@@ -149,7 +154,9 @@ var ClampLines = function (_PureComponent) {
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
-      window.removeEventListener('resize', this.debounced);
+      if (!this.ssr) {
+        window.removeEventListener('resize', this.debounced);
+      }
       this.action = null;
       this.clickHandler = null;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -16,14 +16,19 @@ export default class ClampLines extends PureComponent {
       text: '.',
     };
 
+    // If window is undefined it means the code is executed server-side
+    this.ssr = typeof window === 'undefined';
+
     this.action = this.action.bind(this);
     this.clickHandler = this.clickHandler.bind(this);
 
-    this.debounced = this.debounce(this.action, props.delay);
+    if (!this.ssr) {
+      this.debounced = this.debounce(this.action, props.delay);
+    }
   }
 
   componentDidMount() {
-    if (this.props.text) {
+    if (this.props.text && !this.ssr) {
       this.lineHeight = this.element.clientHeight + 1;
       this.clampLines();
 
@@ -34,7 +39,9 @@ export default class ClampLines extends PureComponent {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.debounced);
+    if (!this.ssr) {
+      window.removeEventListener('resize', this.debounced);
+    }
     this.action = null;
     this.clickHandler = null;
   }


### PR DESCRIPTION
On the server `window` is undefined. As a result any attempt to render a tree containing a `react-clamp-lines` will fail with an `Uncaught ReferenceError`.

This PR address this by wrapping the `window` manipulation with a `if(this.ssr)`, `this.ssr` being `false` when the code is executed in a browser, `true` otherwise.

Since the default value for `state.text` is `"."`, it means that the server will return a pre-constructed markup with only that content. This is ok because most of the time server-side rendering is used to pre-render a page in order to speed up the first load, then a second render occurs client-side, that will in this case apply the clamping.