### PR TITLE
fixes issue where rendered text does not update if the prop changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,13 @@ export default class ClampLines extends PureComponent {
     }
   }
 
+  componentDidUpdate (prevProps) {
+    if (prevProps.text !== this.props.text) {
+      this.original = this.props.text;
+      this.clampLines();
+    }
+  }
+
   debounce(func, wait, immediate) {
     let timeout;
 


### PR DESCRIPTION
re: issue #13 

`shouldComponentUpdate` triggered a warning about using `shouldComponentUpdate` when extending a PureComponent.

`getDerivedStateFromProps` didn't feel quite right to me, as we weren't going to be updating state directly in the hook (ie. it expects an object to be returned to update the state). Per some notes in this hook's documentation, went with `componentDidUpdate`, which solves the problem at hand, and does not seem to affect performance. And it's not deprecated, which is nice.